### PR TITLE
Fix cancel in settings

### DIFF
--- a/OhPoo/Views/HomeView.swift
+++ b/OhPoo/Views/HomeView.swift
@@ -13,6 +13,7 @@ struct HomeView: View {
 	
 	@State private var isSettingsDisplayed: Bool = false
 	@StateObject var pooTimer = PooTimer()
+	@State private var initialEditingTimerDuration: Double = 0.0
 	
 	var body: some View {
 		NavigationStack {
@@ -39,6 +40,7 @@ struct HomeView: View {
 				.toolbar {
 					Button(action: {
 						isSettingsDisplayed = true
+						initialEditingTimerDuration = pooTimer.timerDurationInMinutesAsDouble
 					}) {
 						Image(systemName: "gearshape")
 							.foregroundColor(theme.color)
@@ -52,6 +54,7 @@ struct HomeView: View {
 								ToolbarItem(placement: .topBarLeading) {
 									Button("Cancel") {
 										isSettingsDisplayed = false
+										pooTimer.timerDurationInMinutesAsDouble = initialEditingTimerDuration
 									}
 								}
 								ToolbarItem(placement: .topBarTrailing) {
@@ -61,6 +64,7 @@ struct HomeView: View {
 								}
 							})
 					}
+					.interactiveDismissDisabled()
 				}
 			}
 		}

--- a/OhPoo/Views/HomeView.swift
+++ b/OhPoo/Views/HomeView.swift
@@ -11,9 +11,11 @@ struct HomeView: View {
 	let fullScreenFont: Font = .custom("fullscreen", size: 250)
 	let theme = PooTheme()
 	
-	@State private var isSettingsDisplayed: Bool = false
 	@StateObject var pooTimer = PooTimer()
+	
+	@State private var isSettingsDisplayed: Bool = false
 	@State private var initialEditingTimerDuration: Double = 0.0
+	@State private var saveButtonPressed: Bool = false
 	
 	var body: some View {
 		NavigationStack {
@@ -47,7 +49,12 @@ struct HomeView: View {
 							.fontWeight(.bold)
 					}
 				}
-				.sheet(isPresented: $isSettingsDisplayed) {
+				.sheet(isPresented: $isSettingsDisplayed, onDismiss: {
+					if !saveButtonPressed {
+						pooTimer.timerDurationInMinutesAsDouble = initialEditingTimerDuration
+					}
+					saveButtonPressed = false
+				}) {
 					NavigationStack {
 						SettingsView(isSettingsDisplayed: $isSettingsDisplayed, timerDurationInMinutesAsDouble: $pooTimer.timerDurationInMinutesAsDouble)
 							.toolbar(content: {
@@ -60,11 +67,11 @@ struct HomeView: View {
 								ToolbarItem(placement: .topBarTrailing) {
 									Button("Save") {
 										isSettingsDisplayed = false
+										saveButtonPressed = true
 									}
 								}
 							})
 					}
-					.interactiveDismissDisabled()
 				}
 			}
 		}

--- a/OhPoo/Views/HomeView.swift
+++ b/OhPoo/Views/HomeView.swift
@@ -61,7 +61,6 @@ struct HomeView: View {
 								ToolbarItem(placement: .topBarLeading) {
 									Button("Cancel") {
 										isSettingsDisplayed = false
-										pooTimer.timerDurationInMinutesAsDouble = initialEditingTimerDuration
 									}
 								}
 								ToolbarItem(placement: .topBarTrailing) {

--- a/OhPoo/Views/HomeView.swift
+++ b/OhPoo/Views/HomeView.swift
@@ -13,6 +13,7 @@ struct HomeView: View {
 	
 	@StateObject var pooTimer = PooTimer()
 	
+	@State private var homeScreenTimeValue: Int = 3
 	@State private var isSettingsDisplayed: Bool = false
 	@State private var initialEditingTimerDuration: Double = 0.0
 	@State private var saveButtonPressed: Bool = false
@@ -35,7 +36,7 @@ struct HomeView: View {
 							.font(.system(.title2, weight: .bold))
 							.cornerRadius(15)
 					}
-					Text("\(pooTimer.timerDuration / 60) minutes")
+					Text("\(homeScreenTimeValue) minutes")
 						.foregroundStyle(theme.color)
 						.fontWeight(.semibold)
 				}
@@ -68,6 +69,7 @@ struct HomeView: View {
 									Button("Save") {
 										isSettingsDisplayed = false
 										saveButtonPressed = true
+										homeScreenTimeValue = Int(pooTimer.timerDurationInMinutesAsDouble)
 									}
 								}
 							})

--- a/OhPoo/Views/HomeView.swift
+++ b/OhPoo/Views/HomeView.swift
@@ -50,10 +50,11 @@ struct HomeView: View {
 					}
 				}
 				.sheet(isPresented: $isSettingsDisplayed, onDismiss: {
-					if !saveButtonPressed {
+					if saveButtonPressed {
+						saveButtonPressed = false
+					} else {
 						pooTimer.timerDurationInMinutesAsDouble = initialEditingTimerDuration
 					}
-					saveButtonPressed = false
 				}) {
 					NavigationStack {
 						SettingsView(isSettingsDisplayed: $isSettingsDisplayed, timerDurationInMinutesAsDouble: $pooTimer.timerDurationInMinutesAsDouble)


### PR DESCRIPTION
Updated Settings screen so that the previous duration is maintained when the user taps the Cancel button or swipes down to dismiss the sheet.

Uses three state variables `homeScreenTimeValue`, `initialEditingTimerDuration` and `saveButtonPressed` (default value = `false`):
* `homeScreenTimeValue` is used to store the initial and subsequent values of the timer duration. It is only updated to match `pooTimer.timerDurationInMinutesAsDouble` when the Save button gets pressed. Otherwise, it remains its previous value.
* the initial value of the timer duration when the Settings screen is displayed is saved as `initialEditingTimerDuration`.
* if the Save button is pressed, toggle `saveButtonPressed` to true.
* in the `onDismiss` callback:
  * if `saveButtonPressed` is true, just reset it to `false` for the next time Settings gets opened.
  * if `saveButtonPressed` is false, reset `pooTimer.timerDurationInMinutesAsDouble` to `initialEditingTimerDuration`.