### PR TITLE
Background audio 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 OhPoo.xcodeproj/project.xcworkspace/xcuserdata/carlo.xcuserdatad/UserInterfaceState.xcuserstate
 OhPoo.xcodeproj/xcuserdata/carlo.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+
+.DS_Store

--- a/OhPoo.xcodeproj/project.pbxproj
+++ b/OhPoo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2328092F2B7424CC00F0A1B1 /* LocalNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2328092E2B7424CC00F0A1B1 /* LocalNotifications.swift */; };
 		235A0ADD2B694C0D00C72155 /* OhPooApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 235A0ADC2B694C0D00C72155 /* OhPooApp.swift */; };
 		235A0AE12B694C0E00C72155 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 235A0AE02B694C0E00C72155 /* Assets.xcassets */; };
 		235A0AE42B694C0E00C72155 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 235A0AE32B694C0E00C72155 /* Preview Assets.xcassets */; };
@@ -44,6 +45,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		2328092E2B7424CC00F0A1B1 /* LocalNotifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNotifications.swift; sourceTree = "<group>"; };
 		235A0AD92B694C0D00C72155 /* OhPoo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OhPoo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		235A0ADC2B694C0D00C72155 /* OhPooApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OhPooApp.swift; sourceTree = "<group>"; };
 		235A0AE02B694C0E00C72155 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -157,6 +159,7 @@
 				235A0B182B6950C300C72155 /* PooTheme.swift */,
 				235A0B1C2B6950F200C72155 /* PooTimer.swift */,
 				235A0B262B69C0D100C72155 /* AVPlayer+getAudio.swift */,
+				2328092E2B7424CC00F0A1B1 /* LocalNotifications.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -317,6 +320,7 @@
 			files = (
 				235A0B4B2B715D2F00C72155 /* AppDelegate.swift in Sources */,
 				235A0B272B69C0D100C72155 /* AVPlayer+getAudio.swift in Sources */,
+				2328092F2B7424CC00F0A1B1 /* LocalNotifications.swift in Sources */,
 				235A0B1F2B69512600C72155 /* PooTimerView.swift in Sources */,
 				235A0B252B6952B100C72155 /* SettingsView.swift in Sources */,
 				235A0B1D2B6950F200C72155 /* PooTimer.swift in Sources */,

--- a/OhPoo.xcodeproj/project.pbxproj
+++ b/OhPoo.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		235A0B272B69C0D100C72155 /* AVPlayer+getAudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 235A0B262B69C0D100C72155 /* AVPlayer+getAudio.swift */; };
 		235A0B2B2B69CB5B00C72155 /* fart-05.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 235A0B292B69CB5B00C72155 /* fart-05.mp3 */; };
 		235A0B2C2B69CB5B00C72155 /* toilet-flush-2.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 235A0B2A2B69CB5B00C72155 /* toilet-flush-2.mp3 */; };
+		235A0B4B2B715D2F00C72155 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 235A0B4A2B715D2F00C72155 /* AppDelegate.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -62,6 +63,8 @@
 		235A0B262B69C0D100C72155 /* AVPlayer+getAudio.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVPlayer+getAudio.swift"; sourceTree = "<group>"; };
 		235A0B292B69CB5B00C72155 /* fart-05.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = "fart-05.mp3"; sourceTree = "<group>"; };
 		235A0B2A2B69CB5B00C72155 /* toilet-flush-2.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = "toilet-flush-2.mp3"; sourceTree = "<group>"; };
+		235A0B492B6BCC9400C72155 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		235A0B4A2B715D2F00C72155 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -112,11 +115,13 @@
 		235A0ADB2B694C0D00C72155 /* OhPoo */ = {
 			isa = PBXGroup;
 			children = (
+				235A0B492B6BCC9400C72155 /* Info.plist */,
 				235A0B162B69503A00C72155 /* Models */,
 				235A0B172B69504100C72155 /* Views */,
 				235A0AE02B694C0E00C72155 /* Assets.xcassets */,
 				235A0AE22B694C0E00C72155 /* Preview Content */,
 				235A0B282B69CB2200C72155 /* Resources */,
+				235A0B4A2B715D2F00C72155 /* AppDelegate.swift */,
 			);
 			path = OhPoo;
 			sourceTree = "<group>";
@@ -310,6 +315,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				235A0B4B2B715D2F00C72155 /* AppDelegate.swift in Sources */,
 				235A0B272B69C0D100C72155 /* AVPlayer+getAudio.swift in Sources */,
 				235A0B1F2B69512600C72155 /* PooTimerView.swift in Sources */,
 				235A0B252B6952B100C72155 /* SettingsView.swift in Sources */,
@@ -479,11 +485,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"OhPoo/Preview Content\"";
+				DEVELOPMENT_TEAM = 8R6NX9ZG6T;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = OhPoo/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -496,6 +505,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.carlojacob.OhPoo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -507,11 +517,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"OhPoo/Preview Content\"";
+				DEVELOPMENT_TEAM = 8R6NX9ZG6T;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = OhPoo/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -524,6 +537,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.carlojacob.OhPoo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/OhPoo/AppDelegate.swift
+++ b/OhPoo/AppDelegate.swift
@@ -1,0 +1,25 @@
+//
+//  AppDelegate.swift
+//  OhPoo
+//
+//  Created by Carlo Jacob on 2/5/24.
+//
+
+import Foundation
+import UIKit
+import AVFoundation
+
+class AppDelegate: NSObject, UIApplicationDelegate {
+	func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+		let audioSession = AVAudioSession.sharedInstance()
+
+		do {
+			try audioSession.setCategory(.playback, options: .mixWithOthers)
+			print("Audio set up fine")
+			try audioSession.setActive(true)
+		} catch {
+			print("Unable to set up audio player: \(error.localizedDescription)")
+		}
+		return true
+	}
+}

--- a/OhPoo/AppDelegate.swift
+++ b/OhPoo/AppDelegate.swift
@@ -15,7 +15,6 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 
 		do {
 			try audioSession.setCategory(.playback, options: .mixWithOthers)
-			print("Audio set up fine")
 			try audioSession.setActive(true)
 		} catch {
 			print("Unable to set up audio player: \(error.localizedDescription)")

--- a/OhPoo/Models/LocalNotifications.swift
+++ b/OhPoo/Models/LocalNotifications.swift
@@ -1,0 +1,53 @@
+//
+//  LocalNotifications.swift
+//  OhPoo
+//
+//  Created by Carlo Jacob on 2/7/24.
+//
+
+import Foundation
+import UserNotifications
+
+class LocalNotifications {
+	func registerLocalNotification() {
+		let center = UNUserNotificationCenter.current()
+		
+		center.requestAuthorization(options: [.alert, .badge, .sound]) { permissionGranted, error in
+			if permissionGranted {
+				print("Permission Granted at: \(Date())") // TODO: Update behavior
+			} else {
+				print("Permission NOT Granted at: \(Date())") // TODO: Update behavior
+			}
+		}
+	}
+	
+	func scheduleLocalNotification(secondsRemaining: Int) {
+		// Guardrail to ensure that secondsRemaining > 0
+		guard secondsRemaining > 0 else { return }
+		
+		// Initialize notification center
+		let center = UNUserNotificationCenter.current()
+		
+		// Setup notification content
+		let sound = UNNotificationSound.default // Placeholder for custom sound
+		let content = UNMutableNotificationContent()
+		content.title = "Poo Timer Up!"
+		content.body = "OK, you've been here long enough. Time to clean up and get outta here!"
+		content.sound = sound
+		
+		// Setup notification trigger
+		let triggerTimeInterval = Double(secondsRemaining)
+		print(triggerTimeInterval) // TODO: Remove
+		let trigger = UNTimeIntervalNotificationTrigger(timeInterval: triggerTimeInterval, repeats: false)
+		
+		// Setup request
+		let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger)
+		
+		center.add(request)
+	}
+	
+	func removePendingLocalNotifications() {
+		let center = UNUserNotificationCenter.current()
+		center.removeAllPendingNotificationRequests()
+	}
+}

--- a/OhPoo/Models/PooTimer.swift
+++ b/OhPoo/Models/PooTimer.swift
@@ -32,6 +32,10 @@ class PooTimer: ObservableObject {
 	}
 	private var startDate: Date?
 	
+	// Use to ensure audio plays just once, while a second elapses.
+	private var fartPlayed: Bool = false
+	private var flushPlayed: Bool = false
+	
 	init(timerDuration: Int = 180, timeRemaining: Int = 180) {
 		self.timerDuration = timerDuration
 		self.timeRemaining = timerDuration
@@ -60,13 +64,15 @@ class PooTimer: ObservableObject {
 			timeRemaining = max(timerDuration - timeElapsed, 0)
 			// MARK: Fart audio control
 			// Commented to prevent noise by default each time you start a Poo
-			if timeRemaining == timerDuration {
+			if timeRemaining == timerDuration && !fartPlayed {
 //				playFart()
+				fartPlayed = true
 			}
 			// MARK: Flush audio control
 			// Commented to prevent noise by default each time you finish a Poo
-			if timeRemaining == 0 {
+			if timeRemaining == 0 && !flushPlayed {
 //				playFlush()
+				flushPlayed = true
 				timerStopped = true
 			}
 			self.secondsRemaining = timeRemaining

--- a/OhPoo/Models/PooTimer.swift
+++ b/OhPoo/Models/PooTimer.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import AVFoundation
 
 @MainActor
 class PooTimer: ObservableObject {
@@ -57,9 +58,32 @@ class PooTimer: ObservableObject {
 			let secondsElapsed = Int(Date().timeIntervalSince1970 - startDate.timeIntervalSince1970)
 			timeElapsed = secondsElapsed
 			timeRemaining = max(timerDuration - timeElapsed, 0)
+			// MARK: Fart audio control
+			// Commented to prevent noise by default each time you start a Poo
+			if timeRemaining == timerDuration {
+//				playFart()
+			}
+			// MARK: Flush audio control
+			// Commented to prevent noise by default each time you finish a Poo
+			if timeRemaining == 0 {
+//				playFlush()
+				timerStopped = true
+			}
 			self.secondsRemaining = timeRemaining
 			timerText = timeText
 		}
+	}
+	
+	private func playFart() {
+		var fartPlayer: AVPlayer { AVPlayer.getAudioPlayer(audioFilename: "fart-05") }
+		fartPlayer.seek(to: .zero)
+		fartPlayer.play()
+	}
+	
+	private func playFlush() {
+		var flushPlayer: AVPlayer { AVPlayer.getAudioPlayer(audioFilename: "toilet-flush-2") }
+		flushPlayer.seek(to: .zero)
+		flushPlayer.play()
 	}
 	
 	func reset(timerDuration: Int) {

--- a/OhPoo/Views/CountdownView.swift
+++ b/OhPoo/Views/CountdownView.swift
@@ -11,23 +11,11 @@ import AVFoundation
 struct CountdownView: View {
 	var timerText: String
 	
-	private var flushPlayer: AVPlayer { AVPlayer.getAudioPlayer(audioFilename: "toilet-flush-2") }
-	
 	var body: some View {
-		Text(playFlushAtZero())
+		Text(timerText)
 			.font(.custom("fullscreen", size: 90))
 			.foregroundStyle(PooTheme.pooColor.color)
 			.monospaced()
-	}
-	
-	private func playFlushAtZero() -> String {
-		if timerText == "0:00" {
-			flushPlayer.seek(to: .zero)
-			// MARK: Flush audio control
-			// Commented to prevent noise each time you leave this (or its parent) view open
-			// flushPlayer.play()
-		}
-		return timerText
 	}
 }
 

--- a/OhPoo/Views/HomeView.swift
+++ b/OhPoo/Views/HomeView.swift
@@ -10,6 +10,9 @@ import SwiftUI
 struct HomeView: View {
 	let homeScreenEmojiFont: Font = .custom("homeScreenEmoji", size: 250)
 	let theme = PooTheme()
+	let localNotifications = LocalNotifications()
+	
+	@Environment(\.scenePhase) private var scenePhase
 	
 	@StateObject var pooTimer = PooTimer()
 	
@@ -79,6 +82,19 @@ struct HomeView: View {
 			}
 		}
 		.tint(theme.color)
+		.onAppear {
+			// Request/check permission to send notifications.
+			localNotifications.registerLocalNotification()
+		}
+		.onChange(of: scenePhase, initial: false) { _, newState in
+			// Remove any pending notifications when we return to active.
+			let toActive = newState == .active
+			
+			if toActive {
+				localNotifications.removePendingLocalNotifications()
+				print("Removed pending notifications: at \(Date())") // TODO: Remove
+			}
+		}
 	}
 }
 

--- a/OhPoo/Views/OhPooApp.swift
+++ b/OhPoo/Views/OhPooApp.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 @main
 struct OhPooApp: App {
+	@UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+	
     var body: some Scene {
         WindowGroup {
             HomeView()

--- a/OhPoo/Views/PooTimerView.swift
+++ b/OhPoo/Views/PooTimerView.swift
@@ -12,8 +12,6 @@ struct PooTimerView: View {
 	var timerDuration: Int = 180
 	let theme = PooTheme()
 	
-	private var fartPlayer: AVPlayer { AVPlayer.getAudioPlayer(audioFilename: "fart-05") }
-	
 	@StateObject var pooTimer = PooTimer()
 	
 	var body: some View {
@@ -48,10 +46,6 @@ struct PooTimerView: View {
 	private func startPoo() {
 		pooTimer.reset(timerDuration: timerDuration)
 		pooTimer.startPoo()
-		fartPlayer.seek(to: .zero)
-		// MARK: Fart audio control
-		// Commented to prevent noise each time you open this view
-		// fartPlayer.play()
 	}
 	
 	@MainActor

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- Add list style preferences -->
 <style type="text/css">
     ol ol { list-style-type: lower-alpha; }
-    ol ol ol { list-style-type: lower-roman; }
+    /* ol ol ol { list-style-type: lower-roman; } */
 </style>
 
 # Poo Timer
@@ -51,12 +51,12 @@ I discovered that I can use a `UILocalNotification` to trigger a local push noti
 1. Extract custom font sizes into separate files.
 1. Create one source of truth for `pooTimer`, `theme`, `localNotifications`
 1. Reactive sizing:
-  1. Home screen emoji font size, e.g. minimum of screen width or height plus padding.
-  1. Remaining time on Timer screen.
+    1. Home screen emoji font size, e.g. minimum of screen width or height plus padding.
+    1. Remaining time on Timer screen.
 1. Change Timer value to text after time has expired.
 1. Notification permissions:
-  1. If user declines after the first request, let them know the consequence, and how to turn on Notifications in Settings. Add a link to Settings, if possible.
-  1. Pop up permission alert if the user previously declined to receive notifications (not desirable unless a user can select not to be asked again).
+    1. If user declines after the first request, let them know the consequence, and how to turn on Notifications in Settings. Add a link to Settings, if possible.
+    1. Pop up permission alert if the user previously declined to receive notifications (not desirable unless a user can select not to be asked again).
 1. Create custom audio for end of timer notification.
 1. Research whether navigating to my app to another via the "Back to [App]" button in the top left, or via a push notif, will impact the behavior of my scene change code. It isn't expected as I only check whether I am in the `.active` state.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-<!-- Add list style preferences -->
-<!-- <style type="text/css">
-    /* ol ol { list-style-type: lower-alpha; } */
-    /* ol ol ol { list-style-type: lower-roman; } */
-</style> -->
-
 # Poo Timer
 
 Simple Timer app to reduce time-wasting while using the bathroom.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # Poo Timer
+<!-- Add list style preferences -->
+<style type="text/css">
+    ol ol { list-style-type: lower-alpha; }
+    ol ol ol { list-style-type: lower-roman; }
+</style>
 
 Simple Timer app to reduce time-wasting while using the bathroom.
 
@@ -16,6 +21,18 @@ Note: Pragma marks (`// MARK:`) have been added to `PooTimer.swift` to indicate 
 </p>
 <p align="center">From left to right: Home Screen, Settings Screen, Timer Screen.</p>
 
+## Learnings
+One wish for this app was to play an audio file at the end of the user's timer, even while the app was backgrounded. I learned that although it is possible to continue an audio session into a background state (I implemented this for the starting audio file), it is not possible to start an audio session from a backgrounded state without user/server intervention or a hacked solution. These solutions include:
+
+| Solution | Description |
+| -------- | ----------- |
+| Silent Push Notification | Send a push notification to the app silently, and use it to trigger a new audio session. Silent Push Notifications can only be sent by a server, which is out of the scope of this project. |
+| Background Fetch         | Can be used to start up a background task, however the trigger timing may not be precise and it may not occur at all, if system resources are limited. |
+| Continuous silent audio  | A continuously playing silent audio file for the duration of the timer. This solution is "hacky" and not recommended: it may impact audio from other applications and it will impact phone battery life. |
+
+I discovered that I can use a `UILocalNotification` to trigger a local push notification, including custom audio. I am attempting to implement this.
+
+**Note**: the simulator will play delayed audio, although a real device will not.
 
 ## Future Work
 1. Update "Back" button title to "Home" on Timer screen.
@@ -31,8 +48,16 @@ Note: Pragma marks (`// MARK:`) have been added to `PooTimer.swift` to indicate 
 1. Add loading view, for any delay.
 1. Set the initial value throughout the app at one source, instead of using hardcoded "3" minutes or "180" seconds in various places.
 1. Extract custom font sizes into separate files.
-1. Make home screen emoji font size reactive to screen size, e.g. minimum of screen width or height plus padding.
+1. Create one source of truth for `pooTimer`, `theme`, `localNotifications`
+1. Reactive sizing:
+    1. Home screen emoji font size, e.g. minimum of screen width or height plus padding.
+    1. Remaining time on Timer screen.
+1. Change Timer value to text after time has expired.
+1. Notification permissions:
+    1. If user declines after the first request, let them know the consequence, and how to turn on Notifications in Settings. Add a link to Settings, if possible.
+    1. Pop up permission alert if the user previously declined to receive notifications (not desirable unless a user can select not to be asked again).
+1. Create custom audio for end of timer notification.
+1. Research whether navigating to my app to another via the "Back to [App]" button in the top left, or via a push notif, will impact the behavior of my scene change code. It isn't expected as I only check whether I am in the `.active` state.
 
 ### Known Issues
 1. Colors aren't the same in dark mode.
-1. Audio does not play in background.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Simple Timer app to reduce time-wasting while using the bathroom.
 
 Look out for more updates to come!
 
-Note: Pragma marks (`// MARK:`) have been added to `PooTimerView.swift` and `CountdownView.swift` to indicate where audio is prevented from playing by default. Uncomment lines of the form `// ____Player.play()` to turn on locally. These will be turned off by default in later iterations, with user Settings to turn them on.
+Note: Pragma marks (`// MARK:`) have been added to `PooTimer.swift` to indicate where audio is prevented from playing by default. Uncomment function calls of the form `// play____()` to turn on locally. These will be turned off by default in later iterations, with user Settings to turn them on.
 
 ## Screenshots
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -36,4 +36,3 @@ Note: Pragma marks (`// MARK:`) have been added to `PooTimerView.swift` and `Cou
 ### Known Issues
 1. Colors aren't the same in dark mode.
 1. Audio does not play in background.
-1. Audio does not play in silent mode.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-# Poo Timer
 <!-- Add list style preferences -->
 <style type="text/css">
     ol ol { list-style-type: lower-alpha; }
     ol ol ol { list-style-type: lower-roman; }
 </style>
+
+# Poo Timer
 
 Simple Timer app to reduce time-wasting while using the bathroom.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <!-- Add list style preferences -->
-<style type="text/css">
-    ol ol { list-style-type: lower-alpha; }
+<!-- <style type="text/css">
+    /* ol ol { list-style-type: lower-alpha; } */
     /* ol ol ol { list-style-type: lower-roman; } */
-</style>
+</style> -->
 
 # Poo Timer
 

--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ I discovered that I can use a `UILocalNotification` to trigger a local push noti
 1. Extract custom font sizes into separate files.
 1. Create one source of truth for `pooTimer`, `theme`, `localNotifications`
 1. Reactive sizing:
-    1. Home screen emoji font size, e.g. minimum of screen width or height plus padding.
-    1. Remaining time on Timer screen.
+  1. Home screen emoji font size, e.g. minimum of screen width or height plus padding.
+  1. Remaining time on Timer screen.
 1. Change Timer value to text after time has expired.
 1. Notification permissions:
-    1. If user declines after the first request, let them know the consequence, and how to turn on Notifications in Settings. Add a link to Settings, if possible.
-    1. Pop up permission alert if the user previously declined to receive notifications (not desirable unless a user can select not to be asked again).
+  1. If user declines after the first request, let them know the consequence, and how to turn on Notifications in Settings. Add a link to Settings, if possible.
+  1. Pop up permission alert if the user previously declined to receive notifications (not desirable unless a user can select not to be asked again).
 1. Create custom audio for end of timer notification.
 1. Research whether navigating to my app to another via the "Back to [App]" button in the top left, or via a push notif, will impact the behavior of my scene change code. It isn't expected as I only check whether I am in the `.active` state.
 


### PR DESCRIPTION
- README updates, including new "Learnings" section.
- Allow audio to continue when the app is backgrounded.
- Allow audio to play when the device is on Silent mode.
- Moved audio logic to `PooTimer` and added logic for sounds to play only once.
- Added local notifications to indicate end of timer.
  - Starting a new audio session for the flush sound is out of scope.
  - Check/request notification authorization on app load.
  - Added logic to trigger notif at end of timer, but not if timer is expired or the app state is "inactive".
  - Remove pending notifs whenever the app returns to "active" state.