### PR TITLE
Source of truth for PooTimer

### DIFF
--- a/OhPoo/Models/PooTimer.swift
+++ b/OhPoo/Models/PooTimer.swift
@@ -14,6 +14,8 @@ class PooTimer: ObservableObject {
 	@Published var timerText = "3:00"
 	@Published var timerDuration: Int
 	
+	var theme: PooTheme = PooTheme()
+	
 	private var timer: Timer?
 	private var frequency: TimeInterval { 1.0 / 60.0 }
 	private var timerStopped = false
@@ -100,5 +102,6 @@ class PooTimer: ObservableObject {
 		self.timerDuration = timerDuration
 		secondsRemaining = timerDuration
 		timerDurationInMinutesAsDouble = Double(timerDuration / 60)
+		timerStopped = false
 	}
 }

--- a/OhPoo/Views/CountdownView.swift
+++ b/OhPoo/Views/CountdownView.swift
@@ -9,16 +9,16 @@ import SwiftUI
 import AVFoundation
 
 struct CountdownView: View {
-	var timerText: String
+	@EnvironmentObject var pooTimer: PooTimer
 	
 	var body: some View {
-		Text(timerText)
+		Text(pooTimer.timerText)
 			.font(.custom("fullscreen", size: 90))
-			.foregroundStyle(PooTheme.pooColor.color)
+			.foregroundStyle(pooTimer.theme.color)
 			.monospaced()
 	}
 }
 
 #Preview {
-	CountdownView(timerText: "3:00")
+	CountdownView().environmentObject(PooTimer())
 }

--- a/OhPoo/Views/FillingImageView.swift
+++ b/OhPoo/Views/FillingImageView.swift
@@ -9,20 +9,19 @@ import SwiftUI
 
 struct FillingImageView: View {
 	let timerScreenEmojiFont: Font = .custom("timerScreenEmoji", size: 250)
-	let timerDuration: Int
-	let secondsRemaining: Int
-	let theme = PooTheme()
+
+	@EnvironmentObject var pooTimer: PooTimer
 	
     var body: some View {
 		Text("💩")
 			.font(timerScreenEmojiFont)
 			.overlay(alignment: Alignment(horizontal: .center, vertical: .bottom)) {
-				FillingView(endTime: timerDuration, remainingTime: secondsRemaining)
-					.foregroundColor(theme.lightColor)
+				FillingView(endTime: pooTimer.timerDuration, remainingTime: pooTimer.secondsRemaining)
+					.foregroundColor(pooTimer.theme.lightColor)
 			}
 			.overlay {
 				RoundedRectangle(cornerRadius: 40)
-					.stroke(theme.color, lineWidth: 10)
+					.stroke(pooTimer.theme.color, lineWidth: 10)
 			}
     }
 }
@@ -31,7 +30,7 @@ struct FillingImageView_Preview: PreviewProvider {
 	static var theme = PooTheme()
 	
 	static var previews: some View {
-		FillingImageView(timerDuration: 180, secondsRemaining: 100)
+		FillingImageView().environmentObject(PooTimer())
 			.background(Color(theme.lightColor))
 	}
 }

--- a/OhPoo/Views/HomeView.swift
+++ b/OhPoo/Views/HomeView.swift
@@ -9,12 +9,11 @@ import SwiftUI
 
 struct HomeView: View {
 	let homeScreenEmojiFont: Font = .custom("homeScreenEmoji", size: 250)
-	let theme = PooTheme()
 	let localNotifications = LocalNotifications()
 	
 	@Environment(\.scenePhase) private var scenePhase
 	
-	@StateObject var pooTimer = PooTimer()
+	@EnvironmentObject var pooTimer: PooTimer
 	
 	@State private var homeScreenTimeValue: Int = 3
 	@State private var isSettingsDisplayed: Bool = false
@@ -24,23 +23,23 @@ struct HomeView: View {
 	var body: some View {
 		NavigationStack {
 			ZStack {
-				Color(theme.lightColor)
+				Color(pooTimer.theme.lightColor)
 					.ignoresSafeArea()
 				VStack {
 					Text("💩")
 						.font(homeScreenEmojiFont)
 					NavigationLink {
-						PooTimerView(timerDuration: pooTimer.timerDuration)
+						PooTimerView()
 					} label: {
 						Text("Start Timer")
 							.padding()
-							.background(theme.color)
+							.background(pooTimer.theme.color)
 							.foregroundStyle(Color.white)
 							.font(.system(.title2, weight: .bold))
 							.cornerRadius(15)
 					}
 					Text("\(homeScreenTimeValue) minutes")
-						.foregroundStyle(theme.color)
+						.foregroundStyle(pooTimer.theme.color)
 						.fontWeight(.semibold)
 				}
 				.toolbar {
@@ -60,7 +59,7 @@ struct HomeView: View {
 					}
 				}) {
 					NavigationStack {
-						SettingsView(isSettingsDisplayed: $isSettingsDisplayed, timerDurationInMinutesAsDouble: $pooTimer.timerDurationInMinutesAsDouble)
+						SettingsView(isSettingsDisplayed: $isSettingsDisplayed)
 							.navigationTitle("Settings")
 							.toolbar(content: {
 								ToolbarItem(placement: .topBarLeading) {
@@ -81,7 +80,7 @@ struct HomeView: View {
 				}
 			}
 		}
-		.tint(theme.color)
+		.tint(pooTimer.theme.color)
 		.onAppear {
 			// Request/check permission to send notifications.
 			localNotifications.registerLocalNotification()
@@ -99,5 +98,5 @@ struct HomeView: View {
 }
 
 #Preview {
-	HomeView()
+	HomeView().environmentObject(PooTimer())
 }

--- a/OhPoo/Views/OhPooApp.swift
+++ b/OhPoo/Views/OhPooApp.swift
@@ -10,10 +10,12 @@ import SwiftUI
 @main
 struct OhPooApp: App {
 	@UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+	@StateObject var pooTimer = PooTimer()
 	
     var body: some Scene {
         WindowGroup {
             HomeView()
+				.environmentObject(pooTimer)
         }
     }
 }

--- a/OhPoo/Views/PooTimerView.swift
+++ b/OhPoo/Views/PooTimerView.swift
@@ -9,23 +9,21 @@ import SwiftUI
 import AVFoundation
 
 struct PooTimerView: View {
-	var timerDuration: Int = 180
-	let theme = PooTheme()
 	let localNotifications = LocalNotifications()
 	
-	@StateObject var pooTimer = PooTimer()
+	@EnvironmentObject var pooTimer: PooTimer
 	
 	@Environment(\.scenePhase) private var scenePhase
 	
 	var body: some View {
 		VStack {
 			Spacer()
-			FillingImageView(timerDuration: pooTimer.timerDuration, secondsRemaining: pooTimer.secondsRemaining)
+			FillingImageView()
 			Spacer()
 			ZStack {
 				Circle()
 					.strokeBorder(lineWidth: 30)
-					.foregroundStyle(theme.color)
+					.foregroundStyle(pooTimer.theme.color)
 					.overlay {
 						Circle()
 							.strokeBorder(lineWidth: 18)
@@ -35,9 +33,9 @@ struct PooTimerView: View {
 					.overlay {
 						TimerArc(endTime: pooTimer.timerDuration, currentTime: pooTimer.secondsRemaining)
 							.rotation(Angle(degrees: -90))
-							.stroke(theme.color, lineWidth: 15)
+							.stroke(pooTimer.theme.color, lineWidth: 15)
 					}
-				CountdownView(timerText: pooTimer.timerText)
+				CountdownView()
 			}
 			Spacer()
 		}
@@ -48,7 +46,7 @@ struct PooTimerView: View {
 		.onDisappear {
 			stopPoo()
 		}
-		.background(Color(theme.lightColor))
+		.background(Color(pooTimer.theme.lightColor))
 		// When inactive, the flush sound plays, even with Silent mode on.
 		// When we go to background phase the flush sound doesn't play,
 		// so we set up a local notification to tell the user.
@@ -67,7 +65,7 @@ struct PooTimerView: View {
 	
 	@MainActor
 	private func startPoo() {
-		pooTimer.reset(timerDuration: timerDuration)
+		pooTimer.reset(timerDuration: pooTimer.timerDuration)
 		pooTimer.startPoo()
 	}
 	
@@ -78,5 +76,5 @@ struct PooTimerView: View {
 }
 
 #Preview {
-	PooTimerView(pooTimer: PooTimer(timerDuration: 180))
+	PooTimerView().environmentObject(PooTimer(timerDuration: 180))
 }

--- a/OhPoo/Views/SettingsView.swift
+++ b/OhPoo/Views/SettingsView.swift
@@ -8,12 +8,11 @@
 import SwiftUI
 
 struct SettingsView: View {
-	let theme = PooTheme()
+	@EnvironmentObject var pooTimer: PooTimer
 	
 	@Binding var isSettingsDisplayed: Bool
-	@Binding var timerDurationInMinutesAsDouble: Double
 	private var timerDurationInMinutes: Int {
-		Int(timerDurationInMinutesAsDouble)
+		Int(pooTimer.timerDurationInMinutesAsDouble)
 	}
 	
 	var body: some View {
@@ -21,7 +20,7 @@ struct SettingsView: View {
 			List {
 				Section("Timer Duration") {
 					HStack {
-						Slider(value: $timerDurationInMinutesAsDouble, in: 3...30, step: 1) {
+						Slider(value: $pooTimer.timerDurationInMinutesAsDouble, in: 3...30, step: 1) {
 							Text("Time")
 						}
 						Spacer()
@@ -29,7 +28,7 @@ struct SettingsView: View {
 					}
 				}
 				.fontWeight(.semibold)
-				.foregroundStyle(theme.color)
+				.foregroundStyle(pooTimer.theme.color)
 			}
 		}
 	}
@@ -39,6 +38,6 @@ struct SettingsView_Previews: PreviewProvider {
 	static var lengthInMinutesAsDouble: Double = 3.0
 	
 	static var previews: some View {
-		SettingsView(isSettingsDisplayed: .constant(true), timerDurationInMinutesAsDouble: .constant(lengthInMinutesAsDouble))
+		SettingsView(isSettingsDisplayed: .constant(true)).environmentObject(PooTimer())
 	}
 }

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ I discovered that I can use a `UILocalNotification` to trigger a local push noti
 1. Add loading view, for any delay.
 1. Set the initial value throughout the app at one source, instead of using hardcoded "3" minutes or "180" seconds in various places.
 1. Extract custom font sizes into separate files.
-1. Create one source of truth for `pooTimer`, `theme`, `localNotifications`
 1. Reactive sizing:
     1. Home screen emoji font size, e.g. minimum of screen width or height plus padding.
     1. Remaining time on Timer screen.


### PR DESCRIPTION
Created one source of truth for PooTimer
- Added a `PooTimer` environment object at App level and pass to child.
- `pooTimer` variable accessible and used in most child views.
- Incorporated `PooTheme` into `PooTimer` and use throughout.
- Significantly reduced need to pass values.
- Significantly reduced need to instantiate variables, e.g. `theme`.
- Had to add `timerStopped = false` to `PooTimer.stopPoo`.
- Appended environment object modifier to previews as needed.

Update README
- Removed "Future Work" entry for source of truth.
- Didn't add one for LocalNotifications: those are just function calls.
