### PR TITLE
Add Sound on/off option to Settings screen

### DIFF
--- a/OhPoo.xcodeproj/project.pbxproj
+++ b/OhPoo.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		235A0B2B2B69CB5B00C72155 /* fart-05.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 235A0B292B69CB5B00C72155 /* fart-05.mp3 */; };
 		235A0B2C2B69CB5B00C72155 /* toilet-flush-2.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 235A0B2A2B69CB5B00C72155 /* toilet-flush-2.mp3 */; };
 		235A0B4B2B715D2F00C72155 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 235A0B4A2B715D2F00C72155 /* AppDelegate.swift */; };
+		23D144002B7D080700A4235B /* TrailingIconLabelStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D143FF2B7D080700A4235B /* TrailingIconLabelStyle.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -73,6 +74,7 @@
 		235A0B2A2B69CB5B00C72155 /* toilet-flush-2.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = "toilet-flush-2.mp3"; sourceTree = "<group>"; };
 		235A0B492B6BCC9400C72155 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		235A0B4A2B715D2F00C72155 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		23D143FF2B7D080700A4235B /* TrailingIconLabelStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrailingIconLabelStyle.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -166,6 +168,7 @@
 				2328092E2B7424CC00F0A1B1 /* LocalNotifications.swift */,
 				235A0B182B6950C300C72155 /* PooTheme.swift */,
 				235A0B1C2B6950F200C72155 /* PooTimer.swift */,
+				23D143FF2B7D080700A4235B /* TrailingIconLabelStyle.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -341,6 +344,7 @@
 				235A0B192B6950C300C72155 /* PooTheme.swift in Sources */,
 				235A0ADD2B694C0D00C72155 /* OhPooApp.swift in Sources */,
 				235A0B152B694FBC00C72155 /* HomeView.swift in Sources */,
+				23D144002B7D080700A4235B /* TrailingIconLabelStyle.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OhPoo/Models/PooTimer.swift
+++ b/OhPoo/Models/PooTimer.swift
@@ -13,6 +13,7 @@ class PooTimer: ObservableObject {
 	@Published var secondsRemaining = 180
 	@Published var timerText = "3:00"
 	@Published var timerDuration: Int
+	@Published var timerSoundOn: Bool
 	
 	var theme: PooTheme = PooTheme()
 	
@@ -36,14 +37,15 @@ class PooTimer: ObservableObject {
 	
 	// Use to ensure that audio plays when it should.
 	private var fartPlayed: Bool = false
-	private var shouldPlayFart: Bool { timeRemaining == timerDuration && !fartPlayed }
+	private var shouldPlayFart: Bool { timeRemaining == timerDuration && !fartPlayed && timerSoundOn }
 	private var flushPlayed: Bool = false
 	private var flushTimePassed: Bool = false
-	private var shouldPlayFlush: Bool { timeRemaining == 00 && !flushPlayed && !flushTimePassed }
+	private var shouldPlayFlush: Bool { timeRemaining == 0 && !flushPlayed && !flushTimePassed && timerSoundOn }
 	
-	init(timerDuration: Int = 180, timeRemaining: Int = 180) {
+	init(timerDuration: Int = 180, timeRemaining: Int = 180, timerSoundOn: Bool = false) {
 		self.timerDuration = timerDuration
 		self.timeRemaining = timerDuration
+		self.timerSoundOn = timerSoundOn
 	}
 	
 	func startPoo() {
@@ -68,16 +70,12 @@ class PooTimer: ObservableObject {
 			timeElapsed = secondsElapsed
 			timeRemaining = max(timerDuration - timeElapsed, 0)
 			flushTimePassed = timerDuration - timeElapsed < 0
-			// MARK: Fart audio control
-			// Commented to prevent noise by default each time you start a Poo
 			if shouldPlayFart {
-//				playFart()
+				playFart()
 				fartPlayed = true
 			}
-			// MARK: Flush audio control
-			// Commented to prevent noise by default each time you finish a Poo
 			if shouldPlayFlush {
-//				playFlush()
+				playFlush()
 				flushPlayed = true
 				timerStopped = true
 			}
@@ -100,8 +98,11 @@ class PooTimer: ObservableObject {
 	
 	func reset(timerDuration: Int) {
 		self.timerDuration = timerDuration
-		secondsRemaining = timerDuration
-		timerDurationInMinutesAsDouble = Double(timerDuration / 60)
-		timerStopped = false
+		self.secondsRemaining = timerDuration
+		self.timerDurationInMinutesAsDouble = Double(timerDuration / 60)
+		self.timerStopped = false
+		self.fartPlayed = false
+		self.flushPlayed = false
+		self.flushTimePassed = false
 	}
 }

--- a/OhPoo/Models/TrailingIconLabelStyle.swift
+++ b/OhPoo/Models/TrailingIconLabelStyle.swift
@@ -1,0 +1,8 @@
+//
+//  TrailingIconLabelStyle.swift
+//  OhPoo
+//
+//  Created by Carlo Jacob on 2/14/24.
+//
+
+import Foundation

--- a/OhPoo/Models/TrailingIconLabelStyle.swift
+++ b/OhPoo/Models/TrailingIconLabelStyle.swift
@@ -5,4 +5,17 @@
 //  Created by Carlo Jacob on 2/14/24.
 //
 
-import Foundation
+import SwiftUI
+
+struct TrailingIconLabelStyle: LabelStyle {
+	func makeBody(configuration: Configuration) -> some View {
+		HStack {
+			configuration.title
+			configuration.icon
+		}
+	}
+}
+
+extension LabelStyle where Self == TrailingIconLabelStyle {
+	static var trailingIcon: Self { Self() }
+}

--- a/OhPoo/Views/HomeView.swift
+++ b/OhPoo/Views/HomeView.swift
@@ -59,7 +59,7 @@ struct HomeView: View {
 					}
 				}) {
 					NavigationStack {
-						SettingsView(isSettingsDisplayed: $isSettingsDisplayed)
+						SettingsView()
 							.navigationTitle("Settings")
 							.toolbar(content: {
 								ToolbarItem(placement: .topBarLeading) {

--- a/OhPoo/Views/HomeView.swift
+++ b/OhPoo/Views/HomeView.swift
@@ -66,21 +66,14 @@ struct HomeView: View {
 				}
 				.toolbar {
 					Button(action: {
-						isSettingsDisplayed = true
-						tempSettingsValues.timerDurationInMinutesAsDouble = pooTimer.timerDurationInMinutesAsDouble
-						tempSettingsValues.timerSoundOn = pooTimer.timerSoundOn
+						onSettingsButtonTapped()
 					}) {
 						Image(systemName: "gearshape")
 							.fontWeight(.bold)
 					}
 				}
 				.sheet(isPresented: $isSettingsDisplayed, onDismiss: {
-					if saveButtonPressed {
-						saveButtonPressed = false
-					} else {
-						pooTimer.timerDurationInMinutesAsDouble = tempSettingsValues.timerDurationInMinutesAsDouble
-						pooTimer.timerSoundOn = tempSettingsValues.timerSoundOn
-					}
+					onDismissSettings()
 				}) {
 					NavigationStack {
 						SettingsView()
@@ -93,10 +86,7 @@ struct HomeView: View {
 								}
 								ToolbarItem(placement: .topBarTrailing) {
 									Button("Save") {
-										isSettingsDisplayed = false
-										saveButtonPressed = true
-										homeScreenValues.timeInMinutes = Int(pooTimer.timerDurationInMinutesAsDouble)
-										homeScreenValues.soundOn = pooTimer.timerSoundOn
+										onSaveButtonTapped()
 									}
 								}
 							})
@@ -119,6 +109,28 @@ struct HomeView: View {
 				print("Removed pending notifications: at \(Date())") // TODO: Remove
 			}
 		}
+	}
+	
+	private func onSettingsButtonTapped() {
+		isSettingsDisplayed = true
+		tempSettingsValues.timerDurationInMinutesAsDouble = pooTimer.timerDurationInMinutesAsDouble
+		tempSettingsValues.timerSoundOn = pooTimer.timerSoundOn
+	}
+	
+	private func onDismissSettings() {
+		if saveButtonPressed {
+			saveButtonPressed = false
+		} else {
+			pooTimer.timerDurationInMinutesAsDouble = tempSettingsValues.timerDurationInMinutesAsDouble
+			pooTimer.timerSoundOn = tempSettingsValues.timerSoundOn
+		}
+	}
+	
+	private func onSaveButtonTapped() {
+		isSettingsDisplayed = false
+		saveButtonPressed = true
+		homeScreenValues.timeInMinutes = Int(pooTimer.timerDurationInMinutesAsDouble)
+		homeScreenValues.soundOn = pooTimer.timerSoundOn
 	}
 }
 

--- a/OhPoo/Views/HomeView.swift
+++ b/OhPoo/Views/HomeView.swift
@@ -86,7 +86,7 @@ struct HomeView: View {
 								}
 								ToolbarItem(placement: .topBarTrailing) {
 									Button("Save") {
-										onSaveButtonTapped()
+										onSaveSettingsButtonTapped()
 									}
 								}
 							})
@@ -126,7 +126,7 @@ struct HomeView: View {
 		}
 	}
 	
-	private func onSaveButtonTapped() {
+	private func onSaveSettingsButtonTapped() {
 		isSettingsDisplayed = false
 		saveButtonPressed = true
 		homeScreenValues.timeInMinutes = Int(pooTimer.timerDurationInMinutesAsDouble)

--- a/OhPoo/Views/HomeView.swift
+++ b/OhPoo/Views/HomeView.swift
@@ -60,7 +60,7 @@ struct HomeView: View {
 					}
 				}) {
 					NavigationStack {
-						SettingsView(isSettingsDisplayed: $isSettingsDisplayed, timerDurationInMinutesAsDouble: $pooTimer.timerDurationInMinutesAsDouble)
+						SettingsView(timerDurationInMinutesAsDouble: $pooTimer.timerDurationInMinutesAsDouble)
 							.navigationTitle("Settings")
 							.toolbar(content: {
 								ToolbarItem(placement: .topBarLeading) {

--- a/OhPoo/Views/HomeView.swift
+++ b/OhPoo/Views/HomeView.swift
@@ -7,6 +7,26 @@
 
 import SwiftUI
 
+private struct HomeScreenValues {
+	var timeInMinutes: Int
+	var soundOn: Bool
+	
+	init(timeInMinutes: Int = 3, soundOn: Bool = false) {
+		self.timeInMinutes = timeInMinutes
+		self.soundOn = soundOn
+	}
+}
+
+private struct TempSettingsValues {
+	var timerDurationInMinutesAsDouble: Double
+	var timerSoundOn: Bool
+	
+	init(timerDurationInMinutesAsDouble: Double = 3.0, timerSoundOn: Bool = false) {
+		self.timerDurationInMinutesAsDouble = timerDurationInMinutesAsDouble
+		self.timerSoundOn = timerSoundOn
+	}
+}
+
 struct HomeView: View {
 	let homeScreenEmojiFont: Font = .custom("homeScreenEmoji", size: 250)
 	let localNotifications = LocalNotifications()
@@ -15,17 +35,11 @@ struct HomeView: View {
 	
 	@EnvironmentObject var pooTimer: PooTimer
 	
-	@State private var homeScreenTimeValue: Int = 3
-	@State private var homeScreenSoundOnValue: Bool = false
 	@State private var isSettingsDisplayed: Bool = false
 	@State private var saveButtonPressed: Bool = false
 	
-	private struct InitialEditingSettings {
-		var timerDuration: Double
-		var soundOn: Bool
-	}
-		
-	@State private var initialEditingSettings: InitialEditingSettings = InitialEditingSettings(timerDuration: 0.0, soundOn: false)
+	@State private var homeScreenValues: HomeScreenValues = HomeScreenValues()
+	@State private var tempSettingsValues: TempSettingsValues = TempSettingsValues()
 	
 	var body: some View {
 		NavigationStack {
@@ -45,18 +59,16 @@ struct HomeView: View {
 							.font(.system(.title2, weight: .bold))
 							.cornerRadius(15)
 					}
-					HStack {
-						Text("\(homeScreenTimeValue) minutes")
-						Image(systemName: homeScreenSoundOnValue ? "speaker.wave.3" : "speaker.slash")
-					}
-					.foregroundStyle(pooTimer.theme.color)
-					.fontWeight(.semibold)
+					Label("\(homeScreenValues.timeInMinutes) minutes", systemImage: homeScreenValues.soundOn ? "speaker.wave.3" : "speaker.slash")
+						.labelStyle(.trailingIcon)
+						.foregroundStyle(pooTimer.theme.color)
+						.fontWeight(.semibold)
 				}
 				.toolbar {
 					Button(action: {
 						isSettingsDisplayed = true
-						initialEditingSettings.timerDuration = pooTimer.timerDurationInMinutesAsDouble
-						initialEditingSettings.soundOn = pooTimer.timerSoundOn
+						tempSettingsValues.timerDurationInMinutesAsDouble = pooTimer.timerDurationInMinutesAsDouble
+						tempSettingsValues.timerSoundOn = pooTimer.timerSoundOn
 					}) {
 						Image(systemName: "gearshape")
 							.fontWeight(.bold)
@@ -66,8 +78,8 @@ struct HomeView: View {
 					if saveButtonPressed {
 						saveButtonPressed = false
 					} else {
-						pooTimer.timerDurationInMinutesAsDouble = initialEditingSettings.timerDuration
-						pooTimer.timerSoundOn = initialEditingSettings.soundOn
+						pooTimer.timerDurationInMinutesAsDouble = tempSettingsValues.timerDurationInMinutesAsDouble
+						pooTimer.timerSoundOn = tempSettingsValues.timerSoundOn
 					}
 				}) {
 					NavigationStack {
@@ -83,8 +95,8 @@ struct HomeView: View {
 									Button("Save") {
 										isSettingsDisplayed = false
 										saveButtonPressed = true
-										homeScreenTimeValue = Int(pooTimer.timerDurationInMinutesAsDouble)
-										homeScreenSoundOnValue = pooTimer.timerSoundOn
+										homeScreenValues.timeInMinutes = Int(pooTimer.timerDurationInMinutesAsDouble)
+										homeScreenValues.soundOn = pooTimer.timerSoundOn
 									}
 								}
 							})

--- a/OhPoo/Views/HomeView.swift
+++ b/OhPoo/Views/HomeView.swift
@@ -16,9 +16,16 @@ struct HomeView: View {
 	@EnvironmentObject var pooTimer: PooTimer
 	
 	@State private var homeScreenTimeValue: Int = 3
+	@State private var homeScreenSoundOnValue: Bool = false
 	@State private var isSettingsDisplayed: Bool = false
-	@State private var initialEditingTimerDuration: Double = 0.0
 	@State private var saveButtonPressed: Bool = false
+	
+	private struct InitialEditingSettings {
+		var timerDuration: Double
+		var soundOn: Bool
+	}
+		
+	@State private var initialEditingSettings: InitialEditingSettings = InitialEditingSettings(timerDuration: 0.0, soundOn: false)
 	
 	var body: some View {
 		NavigationStack {
@@ -38,14 +45,18 @@ struct HomeView: View {
 							.font(.system(.title2, weight: .bold))
 							.cornerRadius(15)
 					}
-					Text("\(homeScreenTimeValue) minutes")
-						.foregroundStyle(pooTimer.theme.color)
-						.fontWeight(.semibold)
+					HStack {
+						Text("\(homeScreenTimeValue) minutes")
+						Image(systemName: homeScreenSoundOnValue ? "speaker.wave.3" : "speaker.slash")
+					}
+					.foregroundStyle(pooTimer.theme.color)
+					.fontWeight(.semibold)
 				}
 				.toolbar {
 					Button(action: {
 						isSettingsDisplayed = true
-						initialEditingTimerDuration = pooTimer.timerDurationInMinutesAsDouble
+						initialEditingSettings.timerDuration = pooTimer.timerDurationInMinutesAsDouble
+						initialEditingSettings.soundOn = pooTimer.timerSoundOn
 					}) {
 						Image(systemName: "gearshape")
 							.fontWeight(.bold)
@@ -55,7 +66,8 @@ struct HomeView: View {
 					if saveButtonPressed {
 						saveButtonPressed = false
 					} else {
-						pooTimer.timerDurationInMinutesAsDouble = initialEditingTimerDuration
+						pooTimer.timerDurationInMinutesAsDouble = initialEditingSettings.timerDuration
+						pooTimer.timerSoundOn = initialEditingSettings.soundOn
 					}
 				}) {
 					NavigationStack {
@@ -72,6 +84,7 @@ struct HomeView: View {
 										isSettingsDisplayed = false
 										saveButtonPressed = true
 										homeScreenTimeValue = Int(pooTimer.timerDurationInMinutesAsDouble)
+										homeScreenSoundOnValue = pooTimer.timerSoundOn
 									}
 								}
 							})

--- a/OhPoo/Views/SettingsView.swift
+++ b/OhPoo/Views/SettingsView.swift
@@ -26,17 +26,16 @@ struct SettingsView: View {
 						Text("\(timerDurationInMinutes) minutes")
 					}
 				}
-				.fontWeight(.semibold)
-				.foregroundStyle(pooTimer.theme.color)
+				Section("Timer Sounds") {
+					Toggle("Sounds \(pooTimer.timerSoundOn ? "on" : "off")", isOn: $pooTimer.timerSoundOn)
+				}
 			}
+			.fontWeight(.semibold)
+			.foregroundStyle(pooTimer.theme.color)
 		}
 	}
 }
 
-struct SettingsView_Previews: PreviewProvider {
-	static var lengthInMinutesAsDouble: Double = 3.0
-	
-	static var previews: some View {
-		SettingsView().environmentObject(PooTimer())
-	}
+#Preview {
+	SettingsView().environmentObject(PooTimer())
 }

--- a/OhPoo/Views/SettingsView.swift
+++ b/OhPoo/Views/SettingsView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct SettingsView: View {
 	@EnvironmentObject var pooTimer: PooTimer
 	
-	@Binding var isSettingsDisplayed: Bool
 	private var timerDurationInMinutes: Int {
 		Int(pooTimer.timerDurationInMinutesAsDouble)
 	}
@@ -38,6 +37,6 @@ struct SettingsView_Previews: PreviewProvider {
 	static var lengthInMinutesAsDouble: Double = 3.0
 	
 	static var previews: some View {
-		SettingsView(isSettingsDisplayed: .constant(true)).environmentObject(PooTimer())
+		SettingsView().environmentObject(PooTimer())
 	}
 }

--- a/OhPoo/Views/SettingsView.swift
+++ b/OhPoo/Views/SettingsView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct SettingsView: View {
 	let theme = PooTheme()
 	
-	@Binding var isSettingsDisplayed: Bool
 	@Binding var timerDurationInMinutesAsDouble: Double
 	private var timerDurationInMinutes: Int {
 		Int(timerDurationInMinutesAsDouble)
@@ -39,6 +38,6 @@ struct SettingsView_Previews: PreviewProvider {
 	static var lengthInMinutesAsDouble: Double = 3.0
 	
 	static var previews: some View {
-		SettingsView(isSettingsDisplayed: .constant(true), timerDurationInMinutesAsDouble: .constant(lengthInMinutesAsDouble))
+		SettingsView(timerDurationInMinutesAsDouble: .constant(lengthInMinutesAsDouble))
 	}
 }

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ I discovered that I can use a `UILocalNotification` to trigger a local push noti
     1. Add different filling Timer screen image options (e.g. Roses, Children to school, "2", monarch on a throne)
 1. Make duration selection a pickerwheel, including seconds? This would require an overhaul of the numbers being passed around.
 1. Store audio filenames in enum, rather than as hardcoded strings.
-1. Add loading view, for any delay.
+1. Add loading view, for any delay (this is unlikely to ever show, unless we add server interactions).
 1. Set the initial value throughout the app at one source, instead of using hardcoded "3" minutes or "180" seconds in various places.
 1. Extract custom font sizes into separate files.
 1. Reactive sizing:
@@ -56,5 +56,6 @@ I discovered that I can use a `UILocalNotification` to trigger a local push noti
 1. Research whether navigating to my app to another via the "Back to [App]" button in the top left, or via a push notif, will impact the behavior of my scene change code. It isn't expected as I only check whether I am in the `.active` state.
 1. Periodic alerts/sounds to remind the user about their business.
 1. Different timers/themes. e.g. Kitchen/cooking, task completion.
+1. Store user settings on device.
 
 ### Known Issues/Bugs

--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ This app was built to reduce time-wasting while using the bathroom. Inspired by 
 
 Look out for more updates to come!
 
-**Note**: Pragma marks (`// MARK:`) have been added to `PooTimer.swift` to indicate where audio is prevented from playing by default. Uncomment function calls of the form `// play____()` to turn on locally. These will be turned off by default in later iterations, with user Settings to turn them on.
-
 ## App Structure
 To be added.
 
@@ -42,7 +40,6 @@ I discovered that I can use a `UILocalNotification` to trigger a local push noti
 1. Allow initial timer arc to show a small white section at the top.
 1. Settings additions:
     1. Manually start timer on Timer screen.
-    1. Turn sound on/off (default: off).
     1. Add different filling Timer screen image options (e.g. Roses, Children to school, "2", monarch on a throne)
 1. Make duration selection a pickerwheel, including seconds? This would require an overhaul of the numbers being passed around.
 1. Store audio filenames in enum, rather than as hardcoded strings.


### PR DESCRIPTION
Added toggle to turn sound on/off.
- Default audio off.
- In `PooTimer.swift`:
  - Added `timerSoundOn` boolean to turn sounds on/off.
  - Removed Pragma marks and related comments.
  - Reset audio-related booleans in `.reset()`
- In `HomeView.swift`:
  - Created structs and created instances to store:
    - values of time and sound status on screen.
    - temporary settings values while editing.
  - Added speaker icon to show sound on/off.
    - Replaced `Text` with `Label` and custom style (icon after text).
  - Added logic to edit sound on/off setting on screen and in PooTimer.
  - Extracted logic into functions.
- In `SettingsView.swift`:
  - Added new Section for Timer Sounds.
  - Added toggle for Sound on/off with label that says current state.
  - Restored preview Macro to default.
- Added `TrailingIconLabelStyle` to make Label with title before icon.
- In `README.md`:
  - Removed related Pragma Mark Note and Future Work entry.
  - Made a couple additions to Future Work.