### PR TITLE
Add enum as source of truth for all audio files

### DIFF
--- a/OhPoo.xcodeproj/project.pbxproj
+++ b/OhPoo.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		235A0B2C2B69CB5B00C72155 /* toilet-flush-2.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 235A0B2A2B69CB5B00C72155 /* toilet-flush-2.mp3 */; };
 		235A0B4B2B715D2F00C72155 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 235A0B4A2B715D2F00C72155 /* AppDelegate.swift */; };
 		23D144002B7D080700A4235B /* TrailingIconLabelStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D143FF2B7D080700A4235B /* TrailingIconLabelStyle.swift */; };
+		23D144022B7D6E2600A4235B /* AudioFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D144012B7D6E2600A4235B /* AudioFile.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -75,6 +76,7 @@
 		235A0B492B6BCC9400C72155 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		235A0B4A2B715D2F00C72155 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		23D143FF2B7D080700A4235B /* TrailingIconLabelStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrailingIconLabelStyle.swift; sourceTree = "<group>"; };
+		23D144012B7D6E2600A4235B /* AudioFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioFile.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -169,6 +171,7 @@
 				235A0B182B6950C300C72155 /* PooTheme.swift */,
 				235A0B1C2B6950F200C72155 /* PooTimer.swift */,
 				23D143FF2B7D080700A4235B /* TrailingIconLabelStyle.swift */,
+				23D144012B7D6E2600A4235B /* AudioFile.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -340,6 +343,7 @@
 				232809382B7A86EF00F0A1B1 /* FillingImageView.swift in Sources */,
 				235A0B212B69516A00C72155 /* TimerArc.swift in Sources */,
 				235A0B232B69523A00C72155 /* CountdownView.swift in Sources */,
+				23D144022B7D6E2600A4235B /* AudioFile.swift in Sources */,
 				232809362B7A6C7900F0A1B1 /* FillingView.swift in Sources */,
 				235A0B192B6950C300C72155 /* PooTheme.swift in Sources */,
 				235A0ADD2B694C0D00C72155 /* OhPooApp.swift in Sources */,

--- a/OhPoo/Models/AVPlayer+getAudio.swift
+++ b/OhPoo/Models/AVPlayer+getAudio.swift
@@ -9,23 +9,26 @@ import Foundation
 import AVFoundation
 
 extension AVPlayer {
-	static func getAudioPlayer(audioFilename: String) -> AVPlayer {
-		if audioFilename == "fart-05" {
-			return .getFartAudioPlayer
+	static func getAudioPlayer(audioFilename: AudioFile) -> AVPlayer {
+		switch audioFilename {
+		case .fart:
+			return getFartAudioPlayer
+		case .flush:
+			return getFlushAudioPlayer
+		default:
+			return AVPlayer()
 		}
-		if audioFilename == "toilet-flush-2" {
-			return .getFlushAudioPlayer
-		}
-		return AVPlayer()
 	}
 	
 	static let getFartAudioPlayer: AVPlayer = {
-		guard let url = Bundle.main.url(forResource: "fart-05", withExtension: "mp3") else { fatalError("Failed to find sound file.") }
+		let file = AudioFile.fart
+		guard let url = Bundle.main.url(forResource: file.filename, withExtension: file.fileExtension) else { fatalError("Failed to find sound file.") }
 		return AVPlayer(url: url)
 	}()
 	
 	static let getFlushAudioPlayer: AVPlayer = {
-		guard let url = Bundle.main.url(forResource: "toilet-flush-2", withExtension: "mp3") else { fatalError("Failed to find sound file.") }
+		let file = AudioFile.flush
+		guard let url = Bundle.main.url(forResource: file.filename, withExtension: file.fileExtension) else { fatalError("Failed to find sound file.") }
 		return AVPlayer(url: url)
 	}()
 }

--- a/OhPoo/Models/AudioFile.swift
+++ b/OhPoo/Models/AudioFile.swift
@@ -1,0 +1,29 @@
+//
+//  AudioFile.swift
+//  OhPoo
+//
+//  Created by Carlo Jacob on 2/14/24.
+//
+
+import Foundation
+
+enum AudioFile {
+	case fart
+	case flush
+	case flushShort
+	
+	var filename: String {
+		switch self {
+		case .fart:
+			"fart-05"
+		case .flush:
+			"toilet-flush-2"
+		case .flushShort:
+			"toilet-flush-2-short"
+		}
+	}
+	
+	var fileExtension: String {
+		return "mp3"
+	}
+}

--- a/OhPoo/Models/LocalNotifications.swift
+++ b/OhPoo/Models/LocalNotifications.swift
@@ -30,8 +30,9 @@ class LocalNotifications {
 		
 		// Setup custom sound for notification, or use default
 		var sound: UNNotificationSound
-		let soundName = "toilet-flush-2-short"
-		let soundExtension = "mp3"
+		let flushSound: AudioFile = .flushShort
+		let soundName = flushSound.filename
+		let soundExtension = flushSound.fileExtension
 		if let _ = Bundle.main.url(forResource: soundName, withExtension: soundExtension) {
 			sound = UNNotificationSound(named: UNNotificationSoundName("\(soundName).\(soundExtension)"))
 		} else { sound = UNNotificationSound.default }

--- a/OhPoo/Models/PooTimer.swift
+++ b/OhPoo/Models/PooTimer.swift
@@ -85,13 +85,13 @@ class PooTimer: ObservableObject {
 	}
 	
 	private func playFart() {
-		var fartPlayer: AVPlayer { AVPlayer.getAudioPlayer(audioFilename: "fart-05") }
+		var fartPlayer: AVPlayer { AVPlayer.getAudioPlayer(audioFilename: .fart) }
 		fartPlayer.seek(to: .zero)
 		fartPlayer.play()
 	}
 	
 	private func playFlush() {
-		var flushPlayer: AVPlayer { AVPlayer.getAudioPlayer(audioFilename: "toilet-flush-2") }
+		var flushPlayer: AVPlayer { AVPlayer.getAudioPlayer(audioFilename: .flush) }
 		flushPlayer.seek(to: .zero)
 		flushPlayer.play()
 	}

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ I discovered that I can use a `UILocalNotification` to trigger a local push noti
     1. Manually start timer on Timer screen.
     1. Add different filling Timer screen image options (e.g. Roses, Children to school, "2", monarch on a throne)
 1. Make duration selection a pickerwheel, including seconds? This would require an overhaul of the numbers being passed around.
-1. Store audio filenames in enum, rather than as hardcoded strings.
 1. Add loading view, for any delay (this is unlikely to ever show, unless we add server interactions).
 1. Set the initial value throughout the app at one source, instead of using hardcoded "3" minutes or "180" seconds in various places.
 1. Extract custom font sizes into separate files.


### PR DESCRIPTION
* Store audio filenames and extensions in an enum.
* Reference the enum anytime an audio filename/extension is required.
* Use switch statement in `getAudioPlayer` to ensure that the list of audio files is exhaustive.
* Update README to reflect this addition.