### PR TITLE
Deal with device orientation

### DIFF
--- a/OhPoo.xcodeproj/project.pbxproj
+++ b/OhPoo.xcodeproj/project.pbxproj
@@ -28,6 +28,9 @@
 		235A0B2B2B69CB5B00C72155 /* fart-05.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 235A0B292B69CB5B00C72155 /* fart-05.mp3 */; };
 		235A0B2C2B69CB5B00C72155 /* toilet-flush-2.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 235A0B2A2B69CB5B00C72155 /* toilet-flush-2.mp3 */; };
 		235A0B4B2B715D2F00C72155 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 235A0B4A2B715D2F00C72155 /* AppDelegate.swift */; };
+		235ED7B82B7FE27700EEFEE2 /* HomeContentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 235ED7B72B7FE27700EEFEE2 /* HomeContentsView.swift */; };
+		235ED7BA2B7FEE3900EEFEE2 /* DynamicOrientationStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 235ED7B92B7FEE3900EEFEE2 /* DynamicOrientationStackView.swift */; };
+		235ED7BC2B7FF6E600EEFEE2 /* PooTimerContentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 235ED7BB2B7FF6E600EEFEE2 /* PooTimerContentsView.swift */; };
 		23D144002B7D080700A4235B /* TrailingIconLabelStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D143FF2B7D080700A4235B /* TrailingIconLabelStyle.swift */; };
 		23D144022B7D6E2600A4235B /* AudioFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D144012B7D6E2600A4235B /* AudioFile.swift */; };
 /* End PBXBuildFile section */
@@ -75,6 +78,9 @@
 		235A0B2A2B69CB5B00C72155 /* toilet-flush-2.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = "toilet-flush-2.mp3"; sourceTree = "<group>"; };
 		235A0B492B6BCC9400C72155 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		235A0B4A2B715D2F00C72155 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		235ED7B72B7FE27700EEFEE2 /* HomeContentsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeContentsView.swift; sourceTree = "<group>"; };
+		235ED7B92B7FEE3900EEFEE2 /* DynamicOrientationStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicOrientationStackView.swift; sourceTree = "<group>"; };
+		235ED7BB2B7FF6E600EEFEE2 /* PooTimerContentsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PooTimerContentsView.swift; sourceTree = "<group>"; };
 		23D143FF2B7D080700A4235B /* TrailingIconLabelStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrailingIconLabelStyle.swift; sourceTree = "<group>"; };
 		23D144012B7D6E2600A4235B /* AudioFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioFile.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -183,10 +189,13 @@
 				232809372B7A86EF00F0A1B1 /* FillingImageView.swift */,
 				232809352B7A6C7900F0A1B1 /* FillingView.swift */,
 				235A0B142B694FBC00C72155 /* HomeView.swift */,
+				235ED7B72B7FE27700EEFEE2 /* HomeContentsView.swift */,
 				235A0ADC2B694C0D00C72155 /* OhPooApp.swift */,
 				235A0B1E2B69512600C72155 /* PooTimerView.swift */,
+				235ED7BB2B7FF6E600EEFEE2 /* PooTimerContentsView.swift */,
 				235A0B242B6952B100C72155 /* SettingsView.swift */,
 				235A0B202B69516A00C72155 /* TimerArc.swift */,
+				235ED7B92B7FEE3900EEFEE2 /* DynamicOrientationStackView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -337,6 +346,7 @@
 				235A0B4B2B715D2F00C72155 /* AppDelegate.swift in Sources */,
 				235A0B272B69C0D100C72155 /* AVPlayer+getAudio.swift in Sources */,
 				2328092F2B7424CC00F0A1B1 /* LocalNotifications.swift in Sources */,
+				235ED7B82B7FE27700EEFEE2 /* HomeContentsView.swift in Sources */,
 				235A0B1F2B69512600C72155 /* PooTimerView.swift in Sources */,
 				235A0B252B6952B100C72155 /* SettingsView.swift in Sources */,
 				235A0B1D2B6950F200C72155 /* PooTimer.swift in Sources */,
@@ -344,7 +354,9 @@
 				235A0B212B69516A00C72155 /* TimerArc.swift in Sources */,
 				235A0B232B69523A00C72155 /* CountdownView.swift in Sources */,
 				23D144022B7D6E2600A4235B /* AudioFile.swift in Sources */,
+				235ED7BC2B7FF6E600EEFEE2 /* PooTimerContentsView.swift in Sources */,
 				232809362B7A6C7900F0A1B1 /* FillingView.swift in Sources */,
+				235ED7BA2B7FEE3900EEFEE2 /* DynamicOrientationStackView.swift in Sources */,
 				235A0B192B6950C300C72155 /* PooTheme.swift in Sources */,
 				235A0ADD2B694C0D00C72155 /* OhPooApp.swift in Sources */,
 				235A0B152B694FBC00C72155 /* HomeView.swift in Sources */,

--- a/OhPoo/Views/DynamicOrientationStackView.swift
+++ b/OhPoo/Views/DynamicOrientationStackView.swift
@@ -1,0 +1,41 @@
+//
+//  DynamicOrientationStackView.swift
+//  OhPoo
+//
+//  Created by Carlo Jacob on 2/16/24.
+//
+
+import SwiftUI
+
+struct DynamicOrientationStackView<Content: View>: View {
+	// View Contents to import
+	var content: Content
+	// Used to determine layout of on-screen elements
+	@Environment(\.verticalSizeClass) private var verticalSizeClass: UserInterfaceSizeClass?
+	@Environment(\.horizontalSizeClass) private var horizontalSizeClass: UserInterfaceSizeClass?
+	var isLikelyiPhonePortrait: Bool {
+		horizontalSizeClass == .compact && verticalSizeClass == .regular
+	}
+	var isLikelyiPhoneLandscape: Bool {
+		horizontalSizeClass == .compact && verticalSizeClass == .compact
+	}
+	var isLikelyiPad: Bool {
+		horizontalSizeClass == .regular && verticalSizeClass == .regular
+	}
+	var uncertainDeviceAndOrientation: Bool {
+		horizontalSizeClass == .regular && verticalSizeClass == .compact
+	}
+	
+	var body: some View {
+		if isLikelyiPhonePortrait || isLikelyiPad {
+			VStack {
+				content
+			}
+		}
+		if isLikelyiPhoneLandscape || uncertainDeviceAndOrientation {
+			HStack {
+				content
+			}
+		}
+    }
+}

--- a/OhPoo/Views/HomeContentsView.swift
+++ b/OhPoo/Views/HomeContentsView.swift
@@ -1,0 +1,44 @@
+//
+//  HomeContentsView.swift
+//  OhPoo
+//
+//  Created by Carlo Jacob on 2/16/24.
+//
+
+import SwiftUI
+
+struct HomeContentsView: View {
+	let homeScreenEmojiFont: Font = .custom("homeScreenEmoji", size: 250)
+	let homeScreenValues: HomeScreenValues
+	
+	@EnvironmentObject var pooTimer: PooTimer
+	
+    var body: some View {
+		Spacer()
+		Text("💩")
+			.font(homeScreenEmojiFont)
+		Spacer()
+		VStack {
+			NavigationLink {
+				PooTimerView()
+			} label: {
+				Text("Start Timer")
+					.padding()
+					.background(pooTimer.theme.color)
+					.foregroundStyle(Color.white)
+					.font(.system(.title2, weight: .bold))
+					.cornerRadius(15)
+			}
+			Label("\(homeScreenValues.timeInMinutes) minutes", systemImage: homeScreenValues.soundOn ? "speaker.wave.3" : "speaker.slash")
+				.labelStyle(.trailingIcon)
+				.foregroundStyle(pooTimer.theme.color)
+				.fontWeight(.semibold)
+		}
+		Spacer()
+    }
+}
+
+#Preview() {
+	HomeContentsView(homeScreenValues: HomeScreenValues())
+		.environmentObject(PooTimer())
+}

--- a/OhPoo/Views/HomeView.swift
+++ b/OhPoo/Views/HomeView.swift
@@ -46,35 +46,35 @@ struct HomeView: View {
 				Color(pooTimer.theme.lightColor)
 					.ignoresSafeArea()
 				DynamicOrientationStackView(content: HomeContentsView(homeScreenValues: homeScreenValues))
-				.toolbar {
-					Button(action: {
-						onSettingsButtonTapped()
+					.toolbar {
+						Button(action: {
+							onSettingsButtonTapped()
+						}) {
+							Image(systemName: "gearshape")
+								.fontWeight(.bold)
+						}
+					}
+					.sheet(isPresented: $isSettingsDisplayed, onDismiss: {
+						onDismissSettings()
 					}) {
-						Image(systemName: "gearshape")
-							.fontWeight(.bold)
-					}
-				}
-				.sheet(isPresented: $isSettingsDisplayed, onDismiss: {
-					onDismissSettings()
-				}) {
-					NavigationStack {
-						SettingsView()
-							.navigationTitle("Settings")
-							.toolbar(content: {
-								ToolbarItem(placement: .topBarLeading) {
-									Button("Cancel") {
-										isSettingsDisplayed = false
+						NavigationStack {
+							SettingsView()
+								.navigationTitle("Settings")
+								.toolbar(content: {
+									ToolbarItem(placement: .topBarLeading) {
+										Button("Cancel") {
+											isSettingsDisplayed = false
+										}
 									}
-								}
-								ToolbarItem(placement: .topBarTrailing) {
-									Button("Save") {
-										onSaveSettingsButtonTapped()
+									ToolbarItem(placement: .topBarTrailing) {
+										Button("Save") {
+											onSaveSettingsButtonTapped()
+										}
 									}
-								}
-							})
-							.fontWeight(.semibold)
+								})
+								.fontWeight(.semibold)
+						}
 					}
-				}
 			}
 		}
 		.tint(pooTimer.theme.color)

--- a/OhPoo/Views/HomeView.swift
+++ b/OhPoo/Views/HomeView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-private struct HomeScreenValues {
+struct HomeScreenValues {
 	var timeInMinutes: Int
 	var soundOn: Bool
 	
@@ -28,7 +28,6 @@ private struct TempSettingsValues {
 }
 
 struct HomeView: View {
-	let homeScreenEmojiFont: Font = .custom("homeScreenEmoji", size: 250)
 	let localNotifications = LocalNotifications()
 	
 	@Environment(\.scenePhase) private var scenePhase
@@ -46,24 +45,7 @@ struct HomeView: View {
 			ZStack {
 				Color(pooTimer.theme.lightColor)
 					.ignoresSafeArea()
-				VStack {
-					Text("💩")
-						.font(homeScreenEmojiFont)
-					NavigationLink {
-						PooTimerView()
-					} label: {
-						Text("Start Timer")
-							.padding()
-							.background(pooTimer.theme.color)
-							.foregroundStyle(Color.white)
-							.font(.system(.title2, weight: .bold))
-							.cornerRadius(15)
-					}
-					Label("\(homeScreenValues.timeInMinutes) minutes", systemImage: homeScreenValues.soundOn ? "speaker.wave.3" : "speaker.slash")
-						.labelStyle(.trailingIcon)
-						.foregroundStyle(pooTimer.theme.color)
-						.fontWeight(.semibold)
-				}
+				DynamicOrientationStackView(content: HomeContentsView(homeScreenValues: homeScreenValues))
 				.toolbar {
 					Button(action: {
 						onSettingsButtonTapped()

--- a/OhPoo/Views/PooTimerContentsView.swift
+++ b/OhPoo/Views/PooTimerContentsView.swift
@@ -1,0 +1,40 @@
+//
+//  PooTimerContentsView.swift
+//  OhPoo
+//
+//  Created by Carlo Jacob on 2/16/24.
+//
+
+import SwiftUI
+
+struct PooTimerContentsView: View {
+	@EnvironmentObject var pooTimer: PooTimer
+	
+    var body: some View {
+		Spacer()
+		FillingImageView()
+		Spacer()
+		ZStack {
+			Circle()
+				.strokeBorder(lineWidth: 30)
+				.foregroundStyle(pooTimer.theme.color)
+				.overlay {
+					Circle()
+						.strokeBorder(lineWidth: 18)
+						.foregroundStyle(Color.white)
+						.padding(6)
+				}
+				.overlay {
+					TimerArc(endTime: pooTimer.timerDuration, currentTime: pooTimer.secondsRemaining)
+						.rotation(Angle(degrees: -90))
+						.stroke(pooTimer.theme.color, lineWidth: 15)
+				}
+			CountdownView()
+		}
+		Spacer()
+    }
+}
+
+#Preview {
+	PooTimerContentsView().environmentObject(PooTimer())
+}

--- a/OhPoo/Views/PooTimerView.swift
+++ b/OhPoo/Views/PooTimerView.swift
@@ -17,28 +17,28 @@ struct PooTimerView: View {
 	
 	var body: some View {
 		DynamicOrientationStackView(content: PooTimerContentsView())
-		.padding()
-		.onAppear {
-			startPoo()
-		}
-		.onDisappear {
-			stopPoo()
-		}
-		.background(Color(pooTimer.theme.lightColor))
-		// When inactive, the flush sound plays, even with Silent mode on.
-		// When we go to background phase the flush sound doesn't play,
-		// so we set up a local notification to tell the user.
-		.onChange(of: scenePhase, initial: false) { oldState, newState in
-			let toBackground = newState == .background
-			if pooTimer.secondsRemaining > 0 {
-				if toBackground {
-					// Remove existing notifications before setting up a new one.
-					localNotifications.removePendingLocalNotifications()
-					localNotifications.scheduleLocalNotification(secondsRemaining: pooTimer.secondsRemaining)
-					print("Removed old pending notifs and scheduled a new one after moving from \(oldState) to \(newState): at \(Date())") // TODO: Remove
+			.padding()
+			.onAppear {
+				startPoo()
+			}
+			.onDisappear {
+				stopPoo()
+			}
+			.background(Color(pooTimer.theme.lightColor))
+			// When inactive, the flush sound plays, even with Silent mode on.
+			// When we go to background phase the flush sound doesn't play,
+			// so we set up a local notification to tell the user.
+			.onChange(of: scenePhase, initial: false) { oldState, newState in
+				let toBackground = newState == .background
+				if pooTimer.secondsRemaining > 0 {
+					if toBackground {
+						// Remove existing notifications before setting up a new one.
+						localNotifications.removePendingLocalNotifications()
+						localNotifications.scheduleLocalNotification(secondsRemaining: pooTimer.secondsRemaining)
+						print("Removed old pending notifs and scheduled a new one after moving from \(oldState) to \(newState): at \(Date())") // TODO: Remove
+					}
 				}
 			}
-		}
 	}
 	
 	@MainActor

--- a/OhPoo/Views/PooTimerView.swift
+++ b/OhPoo/Views/PooTimerView.swift
@@ -16,29 +16,7 @@ struct PooTimerView: View {
 	@Environment(\.scenePhase) private var scenePhase
 	
 	var body: some View {
-		VStack {
-			Spacer()
-			FillingImageView()
-			Spacer()
-			ZStack {
-				Circle()
-					.strokeBorder(lineWidth: 30)
-					.foregroundStyle(pooTimer.theme.color)
-					.overlay {
-						Circle()
-							.strokeBorder(lineWidth: 18)
-							.foregroundStyle(Color.white)
-							.padding(6)
-					}
-					.overlay {
-						TimerArc(endTime: pooTimer.timerDuration, currentTime: pooTimer.secondsRemaining)
-							.rotation(Angle(degrees: -90))
-							.stroke(pooTimer.theme.color, lineWidth: 15)
-					}
-				CountdownView()
-			}
-			Spacer()
-		}
+		DynamicOrientationStackView(content: PooTimerContentsView())
 		.padding()
 		.onAppear {
 			startPoo()

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ I discovered that I can use a `UILocalNotification` to trigger a local push noti
 1. Reactive sizing:
     1. Home screen emoji font size, e.g. minimum of screen width or height plus padding.
     1. Remaining time on Timer screen.
+    1. Including max and min values for images and text—including consideration for iPad screens.
 1. Change Timer value to text after time has expired.
 1. Notification permissions:
     1. If user declines after the first request, let them know the consequence, and how to turn on Notifications in Settings. Add a link to Settings, if possible.

--- a/README.md
+++ b/README.md
@@ -57,5 +57,6 @@ I discovered that I can use a `UILocalNotification` to trigger a local push noti
 1. Different timers/themes. e.g. Kitchen/cooking, task completion.
 1. Store user settings on device.
 1. Change `VStack`s to `HStack`s in landscape mode.
+1. Add launch screen file.
 
 ### Known Issues/Bugs

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ I discovered that I can use a `UILocalNotification` to trigger a local push noti
 1. Periodic alerts/sounds to remind the user about their business.
 1. Different timers/themes. e.g. Kitchen/cooking, task completion.
 1. Store user settings on device.
-1. Change `VStack`s to `HStack`s in landscape mode.
 1. Add launch screen file.
 
 ### Known Issues/Bugs


### PR DESCRIPTION
Account for device orientation, including iPad
- Added reusable `DynamicOrientationStackView`:
  - Selects Stack orientation based on UI size classes.
  - Accounts for likely iPhone, iPad and unknown orientations.
  - Accepts `content` view and places in the selected Stack.
- Extracted HomeView/PooTimerView contents into views to be `content`.
- Inserted contents into DynamicOrientationStackView.
- Updated README accordingly.

Additional README edits.